### PR TITLE
updated urls with 3.0 configure.sh endpoints

### DIFF
--- a/aws/archive/ec2.yml
+++ b/aws/archive/ec2.yml
@@ -197,7 +197,7 @@ Resources:
             #!/bin/bash
             set -o errexit
 
-            curl https://archive.landoop.com/repository/cloud/aws/vm/2.3/configure.sh -O
+            curl https://archive.landoop.com/repository/cloud/aws/vm/3.0/configure.sh -O
             chmod +x configure.sh
             ./configure.sh -r ${AWS::Region} \
              -g '${CloudWatchLogsGroup}' \

--- a/aws/docker/ec2.yml
+++ b/aws/docker/ec2.yml
@@ -232,7 +232,7 @@ Resources:
             #!/bin/bash
             set -o errexit
 
-            curl https://archive.landoop.com/repository/cloud/aws/docker/2.3/configure.sh -O
+            curl https://archive.landoop.com/repository/cloud/aws/docker/3.0/configure.sh -O
             chmod +x configure.sh
             ./configure.sh -r ${AWS::Region} \
              -g '${CloudWatchLogsGroup}' \

--- a/aws/ec2-reference/ec2-reference.yaml
+++ b/aws/ec2-reference/ec2-reference.yaml
@@ -290,7 +290,7 @@ Resources:
             #!/bin/bash
             set -o errexit
 
-            curl https://archive.landoop.com/repository/cloud/aws/docker/2.3/configure.sh -O
+            curl https://archive.landoop.com/repository/cloud/aws/docker/3.0/configure.sh -O
             chmod +x configure.sh
             ./configure.sh -r ${AWS::Region} \
              -g '${CloudWatchLogsGroup}' \

--- a/aws/ecs/fargate.yml
+++ b/aws/ecs/fargate.yml
@@ -213,7 +213,7 @@ Resources:
       ContainerDefinitions:
         - Name: lenses
           Essential: true
-          Image: landoop/lenses:2.3
+          Image: lensesio/lenses:3.0
           Cpu: !Ref 'ContainerCpu'
           Memory: !Ref 'ContainerMemory'
           Environment:

--- a/azure/archive/azuredeploy.json
+++ b/azure/archive/azuredeploy.json
@@ -302,7 +302,7 @@
         "typeHandlerVersion": "2.0",
         "autoUpgradeMinorVersion": true,
         "protectedSettings": {
-          "fileUris": ["https://archive.landoop.com/repository/cloud/azure/vm/2.3/configure.sh"],
+          "fileUris": ["https://archive.landoop.com/repository/cloud/azure/vm/3.0/configure.sh"],
           "commandToExecute": "[concat('./configure.sh  -l ', variables('singleQuote'), parameters('lensesLicense'), variables('singleQuote'), ' -z ', variables('singleQuote'), parameters('zookeeper'), variables('singleQuote'), ' -b ',  variables('singleQuote'), parameters('kafkaBrokers'), variables('singleQuote'), ' -s ', variables('singleQuote'), parameters('schemaRegistry'), variables('singleQuote'), ' -c ', variables('singleQuote'), parameters('connect'), variables('singleQuote'))]"
         }
       }

--- a/azure/docker/azuredeploy.json
+++ b/azure/docker/azuredeploy.json
@@ -302,7 +302,7 @@
         "typeHandlerVersion": "2.0",
         "autoUpgradeMinorVersion": true,
         "protectedSettings": {
-          "fileUris": ["https://archive.landoop.com/repository/cloud/azure/docker/2.3/configure.sh"],
+          "fileUris": ["https://archive.landoop.com/repository/cloud/azure/docker/3.0/configure.sh"],
           "commandToExecute": "[concat('./configure.sh  -l ', variables('singleQuote'), parameters('lensesLicense'), variables('singleQuote'), ' -z ', variables('singleQuote'), parameters('zookeeper'), variables('singleQuote'), ' -b ',  variables('singleQuote'), parameters('kafkaBrokers'), variables('singleQuote'), ' -s ', variables('singleQuote'), parameters('schemaRegistry'), variables('singleQuote'), ' -c ', variables('singleQuote'), parameters('connect'), variables('singleQuote'))]"
         }
       }

--- a/azure/hdinsight/azuredeploy.json
+++ b/azure/hdinsight/azuredeploy.json
@@ -88,7 +88,7 @@
         "installScriptActions": [
           {
             "name": "[concat(variables('applicationName'), '-', uniquestring('applicationName'))]",
-            "uri": "https://archive.landoop.com/repository/cloud/azure/hdinsight/2.3/configure.sh",
+            "uri": "https://archive.landoop.com/repository/cloud/azure/hdinsight/3.0/configure.sh",
             "parameters": "[concat('-n ', parameters('clusterName'), ' -l ', variables('singleQuote'), parameters('licenseKey'), variables('singleQuote'))]",
             "roles": [
               "edgenode"

--- a/gcp/container-vm/lenses.jinja
+++ b/gcp/container-vm/lenses.jinja
@@ -13,7 +13,7 @@ resources:
   type: container_instance_template.jinja
   properties:
     zone: {{ properties['zone'] }}
-    dockerImage: landoop/lenses:2.3
+    dockerImage: lensesio/lenses:3.0
     containerImage: family/cos-stable
     port: {{ properties['lensesPort'] }}
     network: {{ properties['network'] }}


### PR DESCRIPTION
`aws/archive/ec2.yml:            curl https://archive.landoop.com/repository/cloud/aws/vm/3.0/configure.sh -O`

`aws/docker/ec2.yml:            curl https://archive.landoop.com/repository/cloud/aws/docker/3.0/configure.sh -O`

`aws/ec2-reference/ec2-reference.yaml:            curl https://archive.landoop.com/repository/cloud/aws/docker/3.0/configure.sh -O`

`aws/ecs/fargate.yml:          Image: lensesio/lenses:3.0`

`aws/eks/lenses.yml:    Default: "eks/3.0.8"`

`azure/archive/azuredeploy.json:          "fileUris": ["https://archive.landoop.com/repository/cloud/azure/vm/3.0/configure.sh"],`

`azure/docker/azuredeploy.json:          "fileUris": ["https://archive.landoop.com/repository/cloud/azure/docker/3.0/configure.sh"],`

`azure/hdinsight/azuredeploy.json:            "uri": "https://archive.landoop.com/repository/cloud/azure/hdinsight/3.0/configure.sh",`

`gcp/container-vm/lenses.jinja:    dockerImage: lensesio/lenses:3.0
`