### PR TITLE
cloud-327

### DIFF
--- a/aws/eks/.gitignore
+++ b/aws/eks/.gitignore
@@ -1,4 +1,5 @@
 modules
 cf
 __pycache__
+venv
 

--- a/aws/eks/Makefile
+++ b/aws/eks/Makefile
@@ -4,10 +4,11 @@ S3Bucket?=vdev-k8
 S3BucketPrefix?=functions
 S3BucketModulesPrefix?=modules
 AWS_DEFAULT_REGION?=eu-north-1
-KafkaClusterName?=vdev-kafka-cluster
+KafkaClusterName?=vdev-kafka
 LensesLicense?=test
 PROFILE?=default
 
+PROJECT=lambdas
 
 .PHONY: inst_deps
 inst_deps:
@@ -21,14 +22,15 @@ cloudformation: s3
 		--profile $(PROFILE) \
 		--stack-name $(STACK_NAME) \
 		--capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
-		--template-body file://lenses.yml \
+		--template-body file://lenses-eks.yml \
 		--output text \
 		--parameters \
 			  ParameterKey=KubeClusterName,ParameterValue=$(KubeClusterName) \
 			  ParameterKey=S3Bucket,ParameterValue=$(S3Bucket) \
 			  ParameterKey=S3BucketPrefix,ParameterValue=$(S3BucketPrefix) \
 			  ParameterKey=KafkaClusterName,ParameterValue=$(KafkaClusterName) \
-			  ParameterKey=LensesLicense,ParameterValue=$(LensesLicense)
+			  ParameterKey=LensesLicense,ParameterValue=$(LensesLicense) \
+			  ParameterKey=LambdaRole,ParameterValue='arn:aws:iam::169480424863:role/vdev-lamda-stack-LambdaProvisioningRole-QZ7JU4W96283'
 
 
 .PHONY: update_cloudformation
@@ -37,7 +39,7 @@ update_cloudformation: s3
 		--profile $(PROFILE) \
 		--stack-name $(STACK_NAME) \
 		--capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
-		--template-body file://lenses.yml \
+		--template-body file://lenses-eks.yml \
 		--parameters \
 			  ParameterKey=KubeClusterName,ParameterValue=$(KubeClusterName) \
 			  ParameterKey=S3Bucket,ParameterValue=$(S3Bucket) \
@@ -63,4 +65,27 @@ s3: zip
 .PHONY: update_lambda
 update_lambda: zip
 	@aws lambda update-function-code --function-name dev-LambdaEKSConfig-NNN --zip-file fileb://lambdas.zip
+
+mkvirtenv:
+	@if [ ! -e venv ]; then \
+			python3 -m virtualenv -p $(shell which python3) venv; \
+			. venv/bin/activate ;\
+			./venv/bin/pip3 install -U pytest flake8 awscli; \
+			./venv/bin/pip3 install -Ur lambdas/requirements.txt; \
+	fi
+
+rmvirtenv:
+	@if command -v deactivate; then \
+			deactivate; \
+	fi
+
+	@rm -rf venv
+
+virtenv: mkvirtenv
+	@. venv/bin/activate ;
+	@pip -V
+
+tests: virtenv
+	@. venv/bin/activate ; python3 -m pytest ./tests/
+
 

--- a/aws/eks/Makefile
+++ b/aws/eks/Makefile
@@ -6,8 +6,8 @@ S3BucketModulesPrefix?=modules
 AWS_DEFAULT_REGION?=eu-north-1
 KafkaClusterName?=vdev-kafka
 LensesLicense?=test
+LambdaRole?=roleArn
 PROFILE?=default
-
 PROJECT=lambdas
 
 .PHONY: inst_deps
@@ -30,7 +30,7 @@ cloudformation: s3
 			  ParameterKey=S3BucketPrefix,ParameterValue=$(S3BucketPrefix) \
 			  ParameterKey=KafkaClusterName,ParameterValue=$(KafkaClusterName) \
 			  ParameterKey=LensesLicense,ParameterValue=$(LensesLicense) \
-			  ParameterKey=LambdaRole,ParameterValue='arn:aws:iam::169480424863:role/vdev-lamda-stack-LambdaProvisioningRole-QZ7JU4W96283'
+			  ParameterKey=LambdaRole,ParameterValue=$(LambdaRole)
 
 
 .PHONY: update_cloudformation

--- a/aws/eks/lambdas/lambdas.py
+++ b/aws/eks/lambdas/lambdas.py
@@ -11,6 +11,8 @@ from exac import exac
 import cfnresponse
 import traceback
 import logging
+import random
+import string
 import json
 
 
@@ -32,6 +34,7 @@ responseData = {
     "LensesService": None,
     "LensesServiceInfo": None,
     "LensesEndpoint": None,
+    "LensesPassword": None,
     "NodePort": None
 }
 
@@ -122,15 +125,20 @@ def main_create(event, context):
             region_name
         )
 
-    # Export Lenses Admin and Password
+
+    # Generate adming credentials
     lenses_admin_username = "admin"
     lenses_admin_password = event['ResourceProperties']['LensesAdminPassword']
+    lenses_admin_password = ''.join(
+        random.choice(string.ascii_letters) for i in range(32)
+    )
+    responseData["LensesPassword"] = lenses_admin_password
 
     try:
         lenses_license = event['ResourceProperties']['LensesLicense']
         if type(json.loads(lenses_license)) is not dict:
             exit(1)
-    except:
+    except json.JSONDecodeError:
         errInfo = exc_info()
         die(
             event,

--- a/aws/eks/lenses-eks.yml
+++ b/aws/eks/lenses-eks.yml
@@ -6,7 +6,6 @@ Metadata:
           default: Lenses Fields (Required)
         Parameters:
           - LensesLicense
-          - LensesAdminPassword
       - Label:
           default: Infrastructure  (Required)
         Parameters: 
@@ -24,8 +23,6 @@ Metadata:
     ParameterLabels:
       LensesLicense:
         default: License (JSON)
-      LensesAdminPassword:
-        default: Admin password (Note the password somewhere.)
       KubeClusterName:
         default: EKS Cluster Name
       KafkaClusterName:
@@ -54,10 +51,6 @@ Parameters:
   LensesLicense:
     Type: String
     Description: You can get a license here https://lenses.io/downloads/lenses-enterprise/. Please use the JSON file here.
-    NoEcho: "true"
-  LensesAdminPassword:
-    Type: String
-    Description: Admin password
     NoEcho: "true"
   LambdaRole:
     Type: String
@@ -196,7 +189,6 @@ Resources:
       ClusterName: !Ref KubeClusterName
       LensesLicense: !Ref LensesLicense
       KafkaClusterName: !Ref KafkaClusterName
-      LensesAdminPassword: !Ref LensesAdminPassword
 
 Outputs:
   LambdaEKSConfigErrorInfo: 
@@ -205,5 +197,7 @@ Outputs:
   LensesURL: 
     Value: !GetAtt LambdaInvoce.LensesEndpoint
     Description: Lenses Endpoint
-
+  LensesAdminPassword:
+    Value: !GetAtt LambdaInvoce.LensesPassword
+    Description: Lenses Password
 

--- a/aws/eks/tests/conftest.py
+++ b/aws/eks/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+import json
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..'))
+)
+sys.path.insert(0, "lambdas")

--- a/aws/eks/tests/test_setup_lenses.py
+++ b/aws/eks/tests/test_setup_lenses.py
@@ -1,0 +1,46 @@
+import yaml
+import json
+import sys
+import os
+
+from setup_lenses import SetupLenes
+configure_lenses = SetupLenes()
+
+class TestSetupLenses():
+
+    # def test_create_license(self):
+    #     lenses_license = {
+    #         "source":"Lenses.io Ltd",
+    #         "clientId":"ClinetTest",
+    #         "details":"Lenses",
+    #         "key":"lenses_key"
+    #     }
+
+    #     # This always fails because we do not json.dump the dict
+    #     self.create_license, err = configure_lenses.CreateLensesLicense(
+    #         secret=lenses_license
+    #     )
+    #     assert err != 0
+
+    def test_create_manifest(self):
+        brokers = "PLAINTEXT://10.164.0.9:51092"
+        zookeepers =  "{url:\"10.164.0.9:51181\",jmx:\"10.164.0.9:51585\"}"
+        lenses_admin_username = "admin"
+        lenses_admin_password = "admin"
+        kafka_metrics_opts = ["{id: 1,  url:\"http://10.164.0.9:11001/metrics\"}"]
+
+        lenses_manifest, err = configure_lenses.CreateLensesManifest(
+            brokers=brokers,
+            zookeepers=zookeepers,
+            username=lenses_admin_username,
+            password=lenses_admin_password,
+            kafka_metrics_opts=kafka_metrics_opts
+        )
+        assert err == 0
+
+    def test_manifest_loads(self):
+        lenses_deployment_manifest = "/tmp/lenses_deployment.yaml"
+        with open(lenses_deployment_manifest) as file:
+            manifest = yaml.full_load(file)
+
+        assert type(manifest) is dict


### PR DESCRIPTION
    Lenses should not be logged in with default admin/admin
    Lenses should use admin/<the-random-password-of-python>
    Output in CFT console for the password
    Unit tests for Lenses python code (only for Lenses Config)